### PR TITLE
Fixed warnings + disabled puppet-lint check for 80chars

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -57,6 +57,7 @@ task :style do
   puts "Checking puppet module code style..."
   linter = PuppetLint.new
   linter.configuration.log_format = '%{path}:%{linenumber}:%{check}:%{KIND}:%{message}'
+  linter.configuration.send("disable_80chars")
 
   FileList['**/*.pp'].each do |puppet_file|
     puts "Evaluating code style for #{puppet_file}"

--- a/examples/init.pp
+++ b/examples/init.pp
@@ -1,6 +1,6 @@
 include limits
 
-limits::conf { "test-soft-nofile": domain => "test", type => "soft", item => "nofile", value => "8192" }
-limits::conf { "test-hard-nofile": domain => "test", type => "hard", item => "nofile", value => "8192" }
-limits::conf { "test-soft-nproc": domain  => "test", type => "soft", item => "nproc", value  => "2048" }
-limits::conf { "test-hard-nproc": domain  => "test", type => "hard", item => "nproc", value  => "2048" }
+limits::conf { 'test-soft-nofile': domain => 'test', type => 'soft', item => 'nofile', value => '8192' }
+limits::conf { 'test-hard-nofile': domain => 'test', type => 'hard', item => 'nofile', value => '8192' }
+limits::conf { 'test-soft-nproc': domain  => 'test', type => 'soft', item => 'nproc', value  => '2048' }
+limits::conf { 'test-hard-nproc': domain  => 'test', type => 'hard', item => 'nproc', value  => '2048' }


### PR DESCRIPTION
I have fixed some warnings and disabled the 80chars check for puppet-lint.
