### PR TITLE
Fixed warnings for top-scope variable

### DIFF
--- a/manifests/packages.pp
+++ b/manifests/packages.pp
@@ -1,6 +1,6 @@
 class limits::packages {
 
-  case $operatingsystem {
+  case $::operatingsystem {
     debian, ubuntu: {
       include limits::packages::debian
     }
@@ -8,7 +8,7 @@ class limits::packages {
       include limits::packages::redhat
     }
     default: {
-      fail("Module ${module_name} is not supported on ${operatingsystem}")
+      fail("Module ${module_name} is not supported on ${::operatingsystem}")
     }
   }
 


### PR DESCRIPTION
Fixed warnings for top-scope variable being used without an explicit namespace.
